### PR TITLE
Feature/fix regex and unrelated histories

### DIFF
--- a/tomono.sh
+++ b/tomono.sh
@@ -27,7 +27,7 @@ function read_repositories {
 
 function remote-branches {
 	git branch -r | grep "^  $1/" | sed -e "s_$1/__"
-}	
+}
 
 # Create a monorepository in a directory "core". Read repositories from STDIN:
 # one line per repository, with two space separated values:
@@ -74,7 +74,7 @@ function create-mono {
 				git rm -rfq --ignore-unmatch .
 				git commit -q --allow-empty -m "Root commit for $branch branch"
 			fi
-			git merge -q --no-commit -s ours "$name/$branch"
+			git merge -q --no-commit -s ours "$name/$branch" --allow-unrelated-histories
 			git read-tree --prefix="$name/" "$name/$branch"
 			git commit -q --no-verify --allow-empty -m "Merging $name to $branch"
 		done

--- a/tomono.sh
+++ b/tomono.sh
@@ -26,7 +26,7 @@ function read_repositories {
 }
 
 function remote-branches {
-	git branch -r | grep "^  $1/" | sed -e 's_.*/__'
+	git branch -r | grep "^  $1/" | sed -e "s_$1/__"
 }	
 
 # Create a monorepository in a directory "core". Read repositories from STDIN:


### PR DESCRIPTION
Hey, this PR changes two things:
- it adds support for branches including slashes, like `feature/bar` or `bugfix/foo`
- it adds the flag `--allow-unrelated-histories` that is needed since git 2.9 (see http://stackoverflow.com/questions/37937984/git-refusing-to-merge-unrelated-histories)