### PR TITLE
Robust handling of remote names

### DIFF
--- a/tomono.sh
+++ b/tomono.sh
@@ -21,12 +21,33 @@ fi
 # Name of the mono repository
 MONOREPO_NAME="core"
 
+# Monorepo directory
+monorepo_dir="$PWD/$MONOREPO_NAME"
+
+
+
+##### FUNCTIONS
+
+# Silent pushd/popd
+pushd () {
+    command pushd "$@" > /dev/null
+}
+
+popd () {
+    command popd "$@" > /dev/null
+}
+
 function read_repositories {
 	sed -e 's/#.*//' | grep .
 }
 
+# List all branches for a given remote
 function remote-branches {
-	git branch -r | grep "^  $1/" | sed -e "s_$1/__"
+	# Ensure we're always in git root
+	pushd "$monorepo_dir"
+	# Cleanest way to list all branches without text editing rigmarole
+	ls ".git/refs/remotes/$1/"
+	popd
 }
 
 # Create a monorepository in a directory "core". Read repositories from STDIN:


### PR DESCRIPTION
Directly list branches from .git meta dir instead of using porcelain
commands. I would have preferred a plumbing command for this but I can't
find any.

Fixes unravelin/tomono#11