### PR TITLE
change delimiters in sed, because path can contain _

### DIFF
--- a/tomono.sh
+++ b/tomono.sh
@@ -26,7 +26,7 @@ function read_repositories {
 }
 
 function remote-branches {
-	git branch -r | grep "^  $1/" | sed -e "s_$1/__"
+	git branch -r | grep "^  $1/" | sed -e "s|$1/||"
 }
 
 # Create a monorepository in a directory "core". Read repositories from STDIN:


### PR DESCRIPTION
I encountered an error when the path of the subdirectory contained `_`, as this was used as sed delimiter:

```sh
$ cat repos.txt | ./tomono.sh --continue
~/dev/project/repo ~/dev/project
Merging in git@gitlab.com:project/repo-with-dashes..
Fetching subdir_with_underscores..
sed: 1: "s_subdir_with_underscores/__
": bad flag in substitute command: 'c'
```

Using `|` as sed delimiter is unlikely to cause any conflict.