### PR TITLE
Add git version to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Features:
 * No conflicts: Each original repository keeps their directory structure, no
   merging required. All files are moved into a subdirectory.
 
+Requirements:
+* git version 2.9+.
+
 ## Usage
 
 Prepare a list of repositories to merge in a file, for example repos.txt:


### PR DESCRIPTION
Helpful to point out git 2.9+ is required. Was trying to run tomono and got `error: unknown option 'allow-unrelated-histories'`, which I think is a 2.9 feature.