### PR TITLE
Allow for a folder prefix for cloning

### DIFF
--- a/tomono.sh
+++ b/tomono.sh
@@ -20,6 +20,7 @@ fi
 
 # Default name of the mono repository (override with envvar)
 : "${MONOREPO_NAME=core}"
+: "${MONOREPO_PREFIX=}"
 
 # Monorepo directory
 monorepo_dir="$PWD/$MONOREPO_NAME"
@@ -124,7 +125,13 @@ function create-mono {
 				git commit -q --allow-empty -m "Root commit for $branch branch"
 			fi
 			git merge -q --no-commit -s ours "$name/$branch" --allow-unrelated-histories
-			git read-tree --prefix="$name/" "$name/$branch"
+
+			if [[ -z "$MONOREPO_PREFIX" ]]; then
+				git read-tree --prefix="$name/" "$name/$branch"
+			else
+				git read-tree --prefix="$MONOREPO_PREFIX/$name/" "$name/$branch"
+			fi
+
 			git commit -q --no-verify --allow-empty -m "Merging $name to $branch"
 		done
 	done


### PR DESCRIPTION
This PR allows adding a folder prefix to clone into a subdirectory of the monorepo. For example, one could clone all repos into the `packages/` folder by doing the following:

```bash
$ cat repos.txt | MONOREPO_NAME=mono MONOREPO_PREFIX=packages tomono
```