### PR TITLE
Support for Lerna-style 'packages' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ $ export MONOREPO_NAME=my_directory
 $ ...
 ```
 
+If you are planning to use a package like [Lerna](https://lernajs.io/) then you
+might need the incoming repositories to be in a subfolder of the repo. To
+accomplish that, use the `PREFIX` envvar:
+
+```sh
+$ export PREFIX=packages/
+$ ...
+```
+
+Note the slash at the end — if you omit it then your repositories will be
+placed in the root but with this string prepended to their names.
+
 ### Tags and namespacing
 
 Note that all tags are namespaced by default: e.g. if your remote `foo` has tags

--- a/tomono.sh
+++ b/tomono.sh
@@ -21,6 +21,10 @@ fi
 # Default name of the mono repository (override with envvar)
 : "${MONOREPO_NAME=core}"
 
+# You can also use the PREFIX envvar. This value will be prepended to the
+# new paths of incoming repositories. It is expected to end in a slash but
+# should work without it.
+
 # Monorepo directory
 monorepo_dir="$PWD/$MONOREPO_NAME"
 
@@ -124,7 +128,7 @@ function create-mono {
 				git commit -q --allow-empty -m "Root commit for $branch branch"
 			fi
 			git merge -q --no-commit -s ours "$name/$branch" --allow-unrelated-histories
-			git read-tree --prefix="$name/" "$name/$branch"
+			git read-tree --prefix="$PREFIX$name/" "$name/$branch"
 			git commit -q --no-verify --allow-empty -m "Merging $name to $branch"
 		done
 	done


### PR DESCRIPTION
I think this used to work natively as slashes were allowed in the repo names but maybe that breaks the namespacing or whatever — this adds an environment variable to enable it again. It's not the nicest solution but it's OK.