### PR TITLE
Use UNIX-agnostic path for bash

### DIFF
--- a/tomono.sh
+++ b/tomono.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Merge multiple repositories into one big monorepo. Migrates every branch in
 # every subrepo to the eponymous branch in the monorepo, with all files


### PR DESCRIPTION
On OS like FreeBSD and Solaris, bash isn't located in the /bin folder when installed.