### PR TITLE
fix: compatibility with git 2.23.0+

### DIFF
--- a/tomono
+++ b/tomono
@@ -64,6 +64,9 @@ while IFS=$'\r'"$IFS" read -r repourl reponame repopath; do
     git fetch --atomic "$reponame"
     
     git branch -r --no-color --list "$reponame/*" --format "%(refname:lstrip=3)" | while read -r branch ; do
+        if [[ "$branch" == "HEAD" ]]; then
+            continue
+        fi
         git read-tree "$empty_tree"
         git read-tree --prefix "$repopath" "refs/remotes/$reponame/$branch"
         tree="$(git write-tree)"


### PR DESCRIPTION
Since git 2.23.0, the list of branches always includes HEAD. Meanwhile, "git read-tree" does not accept HEAD as a valid reference to read from a remote repository. The combination of these two things render tomono unusable with those newer git versions.

As a cross version fix, the "HEAD" is skipped from analysis if present.